### PR TITLE
[ros2] Detect driver version and set the macro with cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,14 @@ elseif($ENV{ROS_VERSION} EQUAL 2)
   find_package(ament_cmake_auto REQUIRED)
   ament_auto_find_build_dependencies()
 
+  if(livox_ros_driver2_FOUND)
+    message(STATUS "Found livox_ros_driver2")
+    add_compile_definitions(LIVOX_ROS_DRIVER2)
+  elseif(livox_ros2_driver_FOUND)
+    message(STATUS "Found livox_ros2_driver")
+    add_compile_definitions(LIVOX_ROS2_DRIVER)
+  endif()
+
   # Component
   ament_auto_add_library(livox_to_pointcloud2 SHARED
     src/livox_to_pointcloud2_ros2.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,6 @@
 cmake_minimum_required(VERSION 3.5.2)
 project(livox_to_pointcloud2)
 
-set(CMAKE_CXX_STANDARD 20)
-
 if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
   set(CMAKE_BUILD_TYPE "RelWithDebInfo" CACHE STRING "Choose the type of build." FORCE)
   set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release" "MinSizeRel" "RelWithDebInfo")

--- a/src/livox_to_pointcloud2_ros2.cpp
+++ b/src/livox_to_pointcloud2_ros2.cpp
@@ -2,9 +2,6 @@
 
 #include <rclcpp_components/register_node_macro.hpp>
 
-#define LIVOX_ROS2_DRIVER
-#define LIVOX_ROS_DRIVER2
-
 #ifdef LIVOX_ROS2_DRIVER
 #include <livox_interfaces/msg/custom_msg.hpp>
 #endif


### PR DESCRIPTION
This package fails to build in the environment where only `livox_ros_driver2` exists.

```
[ 25%] Building CXX object CMakeFiles/livox_to_pointcloud2.dir/src/livox_to_pointcloud2_ros2.cpp.o
/home/obinata/colcon_ws/src/livox_to_pointcloud2/src/livox_to_pointcloud2_ros2.cpp:9:10: fatal error: livox_interfaces/msg/custom_msg.hpp: そのようなファイルやディレクトリはありません
    9 | #include <livox_interfaces/msg/custom_msg.hpp>
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
make[2]: *** [CMakeFiles/livox_to_pointcloud2.dir/build.make:76: CMakeFiles/livox_to_pointcloud2.dir/src/livox_to_pointcloud2_ros2.cpp.o] エラー 1
make[1]: *** [CMakeFiles/Makefile2:139: CMakeFiles/livox_to_pointcloud2.dir/all] エラー 2
make: *** [Makefile:146: all] エラー 2
```

This PR detects the driver version in CMake and defines the macro to switch the header file to be included.